### PR TITLE
update deprecated wx constant names

### DIFF
--- a/src/enotepad_text.erl
+++ b/src/enotepad_text.erl
@@ -192,10 +192,10 @@ undoall_hack(TextCtrl) ->
     wxStyledTextCtrl:clearAll(TextCtrl),
     wxStyledTextCtrl:appendText(TextCtrl, T).
 
--define(none,       ?wxSTC_SCMOD_NORM).
--define(shift,      ?wxSTC_SCMOD_SHIFT).
--define(ctrl,       ?wxSTC_SCMOD_CTRL).
--define(ctrlshift,  ?wxSTC_SCMOD_CTRL bor ?wxSTC_SCMOD_SHIFT).
+-define(none,       ?wxSTC_KEYMOD_NORM).
+-define(shift,      ?wxSTC_KEYMOD_SHIFT).
+-define(ctrl,       ?wxSTC_KEYMOD_CTRL).
+-define(ctrlshift,  ?wxSTC_KEYMOD_CTRL bor ?wxSTC_KEYMOD_SHIFT).
 %% intellij-erlang doesn't like ?M, but the compilers doesn't complain.
 -define(assign(K,M,Cmd), wxStyledTextCtrl:cmdKeyAssign(TextCtrl, K, ?M, Cmd)).
 


### PR DESCRIPTION
Hi there Aaron, I came across this repo in searching for ways to learn how to use wx - it's a fantastic resource, thanks!

On first attempt to run it under latest stable erlang (24.3.2) it didn't compile, so I grepped for the error in the latest wxWidgets headers and found that it was just some renamed constants, so I fixed them in this PR. It runs perfectly otherwise.

What a cool piece of work. Thanks! 👍